### PR TITLE
New attempt for github version upload

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -170,7 +170,7 @@ jobs:
         name: dist
         path: dist
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@main
+      uses: pypa/gh-action-pypi-publish@v0
       with:
         user: __token__
         password: ${{ secrets.pypi_api_token }}


### PR DESCRIPTION
Trying to make automatic pip upload work...

- [ ] Tests added
- [ ] Documentation added
- [ ] Example added (in the documentation, to an existing notebook, or in a new notebook)
- [ ] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/ciceroOslo/ciceroscm/pull/XX>`_) Added feature which does something``)
