### PR TITLE
remove widgets and nbextensions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ The changes listed in this file are categorised as follows:
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed `jupyter nbextension` from `Makefile` causing install errors
+
 ### Added
 
 - Support for flat natural emissions for NO2 and CH4 from gaspamfile as defaults

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,6 @@ $(VENV_DIR): setup.py setup.cfg
 	[ -d $(VENV_DIR) ] || python3 -m venv $(VENV_DIR)
 	$(VENV_DIR)/bin/pip install --upgrade pip wheel
 	$(VENV_DIR)/bin/pip install -e .[dev]
-	$(VENV_DIR)/bin/jupyter nbextension enable --py widgetsnbextension
 
 
 	touch $(VENV_DIR)

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,7 @@ REQUIREMENTS = [
 ]
 
 REQUIREMENTS_NOTEBOOKS = [
-    "ipywidgets",
-    "notebook",
+    "jupyter",
     "seaborn",
 ]
 REQUIREMENTS_TESTS = [


### PR DESCRIPTION
On install using `make venv` I get the following error:

```
Jupyter command `jupyter-nbextension` not found.
make: *** [venv] Error 1
```

If we go to the `Makefile` we have the following lines:

```
        [ -d $(VENV_DIR) ] || python3 -m venv $(VENV_DIR)
        $(VENV_DIR)/bin/pip install --upgrade pip wheel
        $(VENV_DIR)/bin/pip install -e .[dev]
        $(VENV_DIR)/bin/jupyter nbextension enable --py widgetsnbextension
```

Thus, `ciceroscm` is being successfully installed, but the `jupyter nbextension` line is failing.

The `jupyter nbextension` command is out of date moving to JupyterLab (https://bbs.archlinux.org/viewtopic.php?id=292074). I can't easily find a command that replaces this. However, I don't believe that the examples in the `notebooks` directory use anything fancy, so it could probably be safely removed from the `Makefile` and the relevant dependencies deleted from `setup.py`. This pull request does this.

I'm using python 3.10 on Linux.

Confirmed that tests run and that notebooks perform as expected.

- ~[ ] Tests added~
- ~[ ] Documentation added~
- ~[ ] Example added (in the documentation, to an existing notebook, or in a new notebook)~
- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/ciceroOslo/ciceroscm/pull/XX>`_) Added feature which does something``)
