### PR TITLE
Fix carbon cycle output passing in concentrations run

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ The changes listed in this file are categorised as follows:
 ### Fixed
 
 - Skip precaclulation of empty concentrations matrix if emstart >= nyend
+- Carbon cycle output functioninng for concentrations runs
+- Parallel concentrations run pass back-calculated emissions series when prompted for Emissions|CO2
 
 [Version 1.5.0]
 ---------------------------

--- a/src/ciceroscm/carbon_cycle/carbon_cycle_mod.py
+++ b/src/ciceroscm/carbon_cycle/carbon_cycle_mod.py
@@ -766,8 +766,6 @@ class CarbonCycleModel:
             self.pamset["nystart"] + yrix, guess, dtemp=dtemp
         )
         iteration = 0
-        if yrix % 50 == 0:
-            print(f"yr: {yrix} has minguess: {min_guess}, maxguess: {max_guess}")
         while (
             iteration < maxit
             and np.abs(co2_conc_now - estimated_conc) / co2_conc_now > rtol
@@ -784,10 +782,6 @@ class CarbonCycleModel:
                 self.pamset["nystart"] + yrix, guess, dtemp=dtemp
             )
             iteration = iteration + 1
-        if yrix % 50 == 0:
-            print(
-                f"End guess: {guess} {co2_conc_now} and {co2_conc_zero}  and estimated conc {estimated_conc}"
-            )
         return guess
 
     def get_carbon_cycle_output(

--- a/src/ciceroscm/concentrations_emissions_handler.py
+++ b/src/ciceroscm/concentrations_emissions_handler.py
@@ -978,7 +978,10 @@ class ConcentrationsEmissionsHandler:
 
         if self.pamset["conc_run"]:
             df_carbon = self.carbon_cycle.get_carbon_cycle_output(
-                conc_series, conc_run=self.pamset["conc_run"], dtemp_series=dtemp_series
+                self.years,
+                conc_series=conc_series,
+                conc_run=self.pamset["conc_run"],
+                dtemp_series=dtemp_series,
             )
         else:
             em_series = (

--- a/src/ciceroscm/formattingtools/reformat_cscm_results.py
+++ b/src/ciceroscm/formattingtools/reformat_cscm_results.py
@@ -135,7 +135,15 @@ def get_data_from_em(results, variable):
     """
     df_temp = results["emissions"]
     years = df_temp.Year[:]
-    timeseries = df_temp[variable].to_numpy()  # pylint:disable=unsubscriptable-object
+    # If concentrations run, CO2 emissions should be taken from carbon cycle back calculation
+    if "Emissions" in results["carbon cycle"].keys() and variable == "CO2":
+        timeseries = results["carbon cycle"][
+            "Emissions"
+        ].to_numpy()  # pylint:disable=unsubscriptable-object
+    else:
+        timeseries = df_temp[
+            variable
+        ].to_numpy()  # pylint:disable=unsubscriptable-object
     return years, timeseries
 
 

--- a/tests/integration/test_parallel_run.py
+++ b/tests/integration/test_parallel_run.py
@@ -481,3 +481,85 @@ def test_ciceroscm_run_parallel_many_forcing(test_data_dir):
         'variable=="Surface Air Temperature Change" & scenario=="forc_data_zero_forcing" & run_id=="10496_old_NR_rounded"'
     )
     assert len(test_length.values[0]) == 358
+
+
+def test_parallel_conc_run(test_data_dir):
+    scenarios = [
+        {
+            "gaspam_file": os.path.join(test_data_dir, "gases_v1RCMIP.txt"),
+            "nyend": 2100,
+            "conc_run": True,
+            "concentrations_file": os.path.join(test_data_dir, "ssp245_conc_RCMIP.txt"),
+            "emissions_file": os.path.join(test_data_dir, "ssp245_em_RCMIP.txt"),
+            "nat_ch4_file": os.path.join(test_data_dir, "natemis_ch4.txt"),
+            "nat_n2o_file": os.path.join(test_data_dir, "natemis_n2o.txt"),
+            "sunvolc": 1,
+            "scenname": "ssp245conc",
+        }
+    ]
+
+    cfgs = [
+        {
+            "pamset_emiconc": {
+                "qh2o_ch4": 0.171,
+                "qbmb": 0.03,
+                "qo3": 0.4,
+                "qdirso2": -0.457 / 57,
+                "qindso2": -0.514 / 57,
+                "qbc": 0.200 / 7,
+                "qoc": -0.103 / 16,
+            },
+            "pamset_udm": {
+                "rlamdo": 16.0,
+                "akapa": 0.634,
+                "cpi": 0.4,
+                "W": 4.0,
+                "beto": 3.5,
+                "lambda": 0.540,
+                "mixed": 60.0,
+            },
+            "Index": "test_test",
+        },
+        {
+            "pamset_emiconc": {
+                "qh2o_ch4": 0.171,
+                "qbmb": 0.03,
+                "qo3": 0.4,
+                "qdirso2": -0.457 / 57,
+                "qindso2": -0.514 / 57,
+                "qbc": 0.200 / 7,
+                "qoc": -0.103 / 16,
+            },
+            "pamset_udm": {
+                "rlamdo": 16.0,
+                "akapa": 0.634,
+                "cpi": 0.4,
+                "W": 4.0,
+                "beto": 3.5,
+                "lambda": 0.540,
+                "mixed": 60.0,
+                "ocean_efficacy": 1.2,
+            },
+            "Index": "test_test_oceff",
+        },
+    ]
+
+    output_vars = [
+        "Surface Air Temperature Change",
+        "Effective Radiative Forcing",
+        "Emissions|CO2",
+        "Heat Content|Ocean",
+        "Atmospheric Concentrations|CO2",
+        "Effective Radiative Forcing|CO2",
+        "Effective Radiative Forcing|N2O",
+        "Effective Radiative Forcing|CH4",
+        "Effective Radiative Forcing|Aerosols",
+        "Effective Radiative Forcing|F-Gases",
+        "Biosphere carbon flux",
+        "Airborne fraction CO2",
+        "Ocean carbon flux",
+    ]
+
+    results = run_ciceroscm_parallel(scenarios, cfgs, output_vars)
+    print(results)
+    assert set(results["variable"].unique()) == set(output_vars)

--- a/tests/integration/test_parallel_run.py
+++ b/tests/integration/test_parallel_run.py
@@ -540,6 +540,7 @@ def test_parallel_conc_run(test_data_dir):
                 "mixed": 60.0,
                 "ocean_efficacy": 1.2,
             },
+            "pamset_carbon": {"mixed_carbon": 120},
             "Index": "test_test_oceff",
         },
     ]
@@ -561,5 +562,24 @@ def test_parallel_conc_run(test_data_dir):
     ]
 
     results = run_ciceroscm_parallel(scenarios, cfgs, output_vars)
-    print(results)
+    print(results.columns)
     assert set(results["variable"].unique()) == set(output_vars)
+    print(results["run_id"].unique())
+    back_em1 = (
+        results.loc[
+            (results["variable"] == "Emissions|CO2")
+            & (results["run_id"] == "test_test")
+        ]
+        .iloc[:, 7:]
+        .to_numpy(float)
+    )
+    print(back_em1)
+    back_em2 = (
+        results.loc[
+            (results["variable"] == "Emissions|CO2")
+            & (results["run_id"] == "test_test_oceff")
+        ]
+        .iloc[:, 7:]
+        .to_numpy(float)
+    )
+    assert not np.allclose(back_em1, back_em2)


### PR DESCRIPTION
, get back calculated CO2 emissions in this run when running parallel

- [x] Tests added
- [ ] Documentation added
- [ ] Example added (in the documentation, to an existing notebook, or in a new notebook)
- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/ciceroOslo/ciceroscm/pull/XX>`_) Added feature which does something``)
