### PR TITLE
Fix and add test for standalone concentrations emissions handler

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,7 @@ The changes listed in this file are categorised as follows:
 - Skip precaclulation of empty concentrations matrix if emstart >= nyend
 - Carbon cycle output functioninng for concentrations runs
 - Parallel concentrations run pass back-calculated emissions series when prompted for Emissions|CO2
+- Fix so standalone concentrations_emissions_handler will run without explicitly sending carbon cycle model argument, ensuring backward compatibility.
 
 ### Removed
 - Removed old calibrator code, as calibration is now done in a separate repository.

--- a/src/ciceroscm/concentrations_emissions_handler.py
+++ b/src/ciceroscm/concentrations_emissions_handler.py
@@ -57,25 +57,21 @@ def check_pamset(pamset):
         "qnmvoc": 0.0,
         "qnh3": 0.0,
         "qnox": 0.0,
-        "ml_w_sigmoid": 3.0,
-        "ml_fracmax": 0.5,
-        "ml_t_half": 0.5,
-        "npp0": 60.0,
-        "npp_t_half": 0.5,
-        "npp_w_sigmoid": 7,
-        "npp_t_threshold": 4,
-        "npp_w_threshold": 7,
-        "solubility_sens": 0.02,
-        "solubility_limit": 0.5,
+        "idtm": 24,
+        "nystart": 1750,
+        "nyend": 2100,
+        "emstart": 1850,
     }
 
     # pamset = check_numeric_pamset(required, pamset, )
     if "lifetime_mode" not in pamset:
         pamset["lifetime_mode"] = "TAR"
-
+    if "carbon_cycle_model" not in pamset:
+        pamset["carbon_cycle_model"] = "default"
     used = {
         "lifetime_mode": "TAR",
         "just_one": "CO2",
+        "carbon_cycle_model": "default",
         "idtm": 24,
         "nystart": 1750,
         "nyend": 2100,
@@ -191,15 +187,8 @@ class ConcentrationsEmissionsHandler:
         self.forc = {}
         self.nat_emis_ch4 = input_handler.get_data("nat_ch4")
         self.nat_emis_n2o = input_handler.get_data("nat_n2o")
-        print("Carbon Model=" + pamset["carbon_cycle_model"])
-        self.pamset = cut_and_check_pamset(
-            {"idtm": 24, "nystart": 1750, "nyend": 2100, "emstart": 1850},
-            pamset,
-            used={
-                "carbon_cycle_model": "default",
-            },
-            cut_warnings=True,
-        )
+        self.pamset = check_pamset(pamset)
+        print("Carbon Model=" + self.pamset["carbon_cycle_model"])
         self.years = np.arange(self.pamset["nystart"], self.pamset["nyend"] + 1)
         self.conc_in = input_handler.get_data("concentrations")
         self.emis = input_handler.get_data("emissions")

--- a/src/ciceroscm/concentrations_emissions_handler.py
+++ b/src/ciceroscm/concentrations_emissions_handler.py
@@ -188,7 +188,6 @@ class ConcentrationsEmissionsHandler:
         self.nat_emis_ch4 = input_handler.get_data("nat_ch4")
         self.nat_emis_n2o = input_handler.get_data("nat_n2o")
         self.pamset = check_pamset(pamset)
-        print("Carbon Model=" + self.pamset["carbon_cycle_model"])
         self.years = np.arange(self.pamset["nystart"], self.pamset["nyend"] + 1)
         self.conc_in = input_handler.get_data("concentrations")
         self.emis = input_handler.get_data("emissions")
@@ -333,7 +332,7 @@ class ConcentrationsEmissionsHandler:
         )
         self.precalc_dict["precalc_erf"]["STRAT_O3"] = q
 
-    def reset_with_new_pams(self, pamset, pamset_carbon, preexisting=True):
+    def reset_with_new_pams(self, pamset, pamset_carbon=None, preexisting=True):
         """
         Reset to run again with same emissions etc.
 

--- a/tests/unit/test_concentrations_emissions_handler_standalone.py
+++ b/tests/unit/test_concentrations_emissions_handler_standalone.py
@@ -1,0 +1,25 @@
+import os
+
+from ciceroscm import concentrations_emissions_handler, input_handler
+
+
+def test_ce_handler_init(test_data_dir):
+    ce_handler = concentrations_emissions_handler.ConcentrationsEmissionsHandler(
+        input_handler.InputHandler(
+            {
+                "gaspam_file": os.path.join(
+                    test_data_dir, "gases_vupdate_2022_AR6.txt"
+                ),
+                "concentrations_file": os.path.join(
+                    test_data_dir, "ssp245_conc_RCMIP.txt"
+                ),
+                "emissions_file": os.path.join(test_data_dir, "ssp245_em_RCMIP.txt"),
+                "nat_ch4_file": os.path.join(test_data_dir, "natemis_ch4.txt"),
+                "nat_n2o_file": os.path.join(test_data_dir, "natemis_n2o.txt"),
+                "nystart": 1750,
+                "nyend": 2100,
+            }
+        ),
+        pamset={"lifetime_mode": "CONSTANT_12"},
+    )
+    assert ce_handler.pamset["carbon_cycle_model"] == "default"

--- a/tests/unit/test_concentrations_emissions_handler_standalone.py
+++ b/tests/unit/test_concentrations_emissions_handler_standalone.py
@@ -23,3 +23,6 @@ def test_ce_handler_init(test_data_dir):
         pamset={"lifetime_mode": "CONSTANT_12"},
     )
     assert ce_handler.pamset["carbon_cycle_model"] == "default"
+    ce_handler.reset_with_new_pams({"qo3": 0.4})
+    assert ce_handler.pamset["qo3"] == 0.4
+    assert ce_handler.pamset["qnh3"] == 0.0


### PR DESCRIPTION
Bug that made stand alone concentrations emissions handler runs brittle and not backword compatible with new structural switch setup. This is to fix this and add test coverage for this usecase.

- [x] Tests added
- [x] Documentation added
- [x] Example added (in the documentation, to an existing notebook, or in a new notebook)
- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/ciceroOslo/ciceroscm/pull/XX>`_) Added feature which does something``)
