### PR TITLE
Fix carbon_cycle_outputs presence check (~30x perf bug)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ The changes listed in this file are categorised as follows:
 
 ### Fixed
 - Temperature feedbacks were not passed to partial_pressure calculation in carbon cycle, meaning that the carbon cycle was not responding to temperature changes, this is now fixed and the carbon cycle will respond to temperature changes through the temperature feedbacks to ocean solubility and mixed layer depth.
+- ``ConcentrationsEmissionsHandler`` carbon-cycle output gating was a key-presence check (``if "carbon_cycle_outputs" in cfg:``) rather than a value check, so passing ``carbon_cycle_outputs=False`` still triggered the expensive back-calculation. Since ``CSCMParWrapper.run_over_cfgs`` always passes the key, every CICEROSCM run paid the cost (~30-50x per-member runtime on conc-driven runs). Gating is now ``if cfg.get("carbon_cycle_outputs"):``; ``False`` (or omitting the key) skips the back-calculation as intended. Regression test added in ``tests/integration/test_carbon_cycle_variables_integrated.py``.
 
 ### Changed
 - Integral convolution in carbon cycle changed from using np.dot to np.einsum which leads to a significant speed up for longer timeseries on linux machines.

--- a/src/ciceroscm/concentrations_emissions_handler.py
+++ b/src/ciceroscm/concentrations_emissions_handler.py
@@ -948,7 +948,7 @@ class ConcentrationsEmissionsHandler:
                 "conc", results_dict["concentrations"], outdir, self.df_gas["CONC_UNIT"]
             )
 
-        if "carbon_cycle_outputs" in cfg:
+        if cfg.get("carbon_cycle_outputs"):
             # Adding carbon cycle outputs here
             # Typically back_calculated emissions for conc_run
             # Airborne fraction
@@ -1021,7 +1021,7 @@ class ConcentrationsEmissionsHandler:
         results["concentrations"] = df_conc
         results["forcing"] = df_forc
 
-        if "carbon_cycle_outputs" in cfg:
+        if cfg.get("carbon_cycle_outputs"):
             results["carbon cycle"] = self.get_carbon_cycle_data(
                 feedback_dict_series=feedback_dict_series
             )

--- a/tests/integration/test_carbon_cycle_variables_integrated.py
+++ b/tests/integration/test_carbon_cycle_variables_integrated.py
@@ -221,3 +221,50 @@ def test_changing_carbon_cycle_parameters(test_data_dir):
         if key == "CO2 concentration":
             continue
         assert not np.allclose(value, default_results[key])
+
+
+def test_carbon_cycle_outputs_false_skips_back_calculation(test_data_dir):
+    """
+    Passing ``carbon_cycle_outputs=False`` must skip the carbon-cycle
+    back-calculation (regression test).
+
+    The pre-fix code gated the carbon-cycle output via
+    ``if "carbon_cycle_outputs" in cfg:``, i.e. a key-presence check
+    rather than a value check. That meant passing the key with value
+    ``False`` (or any falsy value) still triggered the expensive
+    back-calculation. After the fix the gating is a value check, so
+    ``False`` skips the work and ``"carbon cycle"`` does not appear in
+    ``results``.
+    """
+    cscm = CICEROSCM(
+        {
+            "gaspam_file": os.path.join(test_data_dir, "gases_v1RCMIP.txt"),
+            "nystart": 1900,
+            "emstart": 1950,
+            "nyend": 2015,
+            "concentrations_file": os.path.join(test_data_dir, "ssp245_conc_RCMIP.txt"),
+            "emissions_file": os.path.join(test_data_dir, "ssp245_em_RCMIP.txt"),
+            "nat_ch4_file": os.path.join(test_data_dir, "natemis_ch4.txt"),
+            "nat_n2o_file": os.path.join(test_data_dir, "natemis_n2o.txt"),
+            "idtm": 24,
+        },
+    )
+
+    cscm._run({"results_as_dict": True})
+    assert "carbon cycle" not in cscm.results, (
+        "Omitting the carbon_cycle_outputs key should leave "
+        "results['carbon cycle'] unset"
+    )
+
+    cscm._run({"results_as_dict": True, "carbon_cycle_outputs": False})
+    assert "carbon cycle" not in cscm.results, (
+        "carbon_cycle_outputs=False should skip back-calculation; "
+        "results['carbon cycle'] should not be set (regression: "
+        "previous key-presence check triggered it for any value)"
+    )
+
+    cscm._run({"results_as_dict": True, "carbon_cycle_outputs": True})
+    assert "carbon cycle" in cscm.results, (
+        "carbon_cycle_outputs=True should run the back-calculation "
+        "and populate results['carbon cycle']"
+    )


### PR DESCRIPTION
## Summary

`ConcentrationsEmissionsHandler` gates the carbon-cycle back-calculation by checking *key presence* rather than value:

```python
if "carbon_cycle_outputs" in cfg:                   # WRONG
    results["carbon cycle"] = self.get_carbon_cycle_data(...)
```

`CSCMParWrapper.run_over_cfgs` always passes the key (default `True`), so the back-calculation runs for every `CICEROSCM._run` invocation regardless of value. The cost is ~30-50x per member on conc-driven runs, so this is a non-trivial perf regression for any caller passing `carbon_cycle_outputs=False`.

## Measurement (ssp245 conc-driven, nyend=2500, single member, this branch's tests)

| `_run(cfg=...)`                                                          | Wall time |
|--------------------------------------------------------------------------|----------:|
| `{'results_as_dict': True}`                                              | 1.54 s    |
| `{'results_as_dict': True, 'carbon_cycle_outputs': False}` (pre-fix)     | **48.84 s** ⚠ |
| `{'results_as_dict': True, 'carbon_cycle_outputs': True}`                | 49.15 s   |
| `{'results_as_dict': True, 'carbon_cycle_outputs': False}` (post-fix)    | ~1.5 s    |
| `{'results_as_dict': True, 'carbon_cycle_outputs': True}` (post-fix)     | ~49 s     |

So `carbon_cycle_outputs=False` was *silently* 30x slower than omitting the key entirely - a counter-intuitive result for any caller trying to disable the feature.

## Patch

Change the gating in `concentrations_emissions_handler.py` at both call sites (the file-output `make_output` block and the in-memory `add_results_to_dict` builder) from a presence check to a value check via `cfg.get(...)`.

## Test

Regression test added in `tests/integration/test_carbon_cycle_variables_integrated.py::test_carbon_cycle_outputs_false_skips_back_calculation`. It asserts that:

- omitting the key → no `'carbon cycle'` in `results`
- `carbon_cycle_outputs=False` → no `'carbon cycle'` in `results` (the regression)
- `carbon_cycle_outputs=True` → `'carbon cycle'` in `results`

## Discovery context

Found while wiring CICEROSCM v2.x into openscm-runner's operational RCMIP runner ([benmsanderson/openscm-runner#8](https://github.com/benmsanderson/openscm-runner/pull/8)). The runner currently ships a downstream monkey-patch that strips the False-valued key before each `_run` call; once this fix lands the workaround can be removed.

Drafted as a draft PR for Marit's review.

## Test plan
- [x] New regression test passes locally
- [x] Existing `tests/integration/test_carbon_cycle_variables_integrated.py` tests still pass
- [ ] Reviewer to confirm no other call sites depend on the old presence semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)