### PR TITLE
Changelog fix for versionbump

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ The changes listed in this file are categorised as follows:
     - Fixed: any bug fixes
     - Security: in case of vulnerabilities.
 
-[Unreleased]
+[Version 2.1.2]
 ---------------------------
 
 ### Changed


### PR DESCRIPTION
Just what it says in the headline

- [x] Description in ``CHANGELOG.rst`` added (single line such as: ``(`#XX <https://github.com/ciceroOslo/ciceroscm/pull/XX>`_) Added feature which does something``)
